### PR TITLE
[Entrypoints] Add vllm.router_plugins entry point group to build_app()

### DIFF
--- a/tests/entrypoints/test_router_plugins.py
+++ b/tests/entrypoints/test_router_plugins.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for the vllm.router_plugins entry point hook in build_app().
+
+These tests call the plugin-attachment logic directly so no GPU, no real
+entry points, and no fully-constructed args namespace are required.
+"""
+
+import logging
+from unittest.mock import MagicMock, call
+
+import pytest
+from fastapi import FastAPI
+
+
+def _run_plugin_attachment(monkeypatch, plugins: dict):
+    """
+    Exercise only the router-plugin loop from build_app() by patching
+    load_plugins_by_group and calling a minimal reproduction of the loop.
+
+    Returns (app, log_records) so tests can assert on both.
+    """
+    from vllm.entrypoints.openai import api_server
+
+    fake_app = FastAPI()
+    fake_load = MagicMock(return_value=plugins)
+    monkeypatch.setattr(api_server, "load_plugins_by_group", fake_load)
+
+    # Re-import the patched reference so the loop uses our mock
+    load_plugins_by_group = api_server.load_plugins_by_group
+    logger = logging.getLogger("vllm.entrypoints.openai.api_server")
+
+    router_plugins = load_plugins_by_group("vllm.router_plugins")
+    for name, attach_fn in router_plugins.items():
+        logger.debug("Attaching router plugin: %s", name)
+        try:
+            attach_fn(fake_app)  # type: ignore[call-arg]
+        except Exception:
+            logger.exception("Failed to attach router plugin: %s", name)
+
+    return fake_app
+
+
+def test_no_plugins_installed(monkeypatch):
+    """No-op when no router plugins are registered; app is still a valid FastAPI instance."""
+    app = _run_plugin_attachment(monkeypatch, plugins={})
+    assert isinstance(app, FastAPI)
+
+
+def test_one_plugin_called_with_app(monkeypatch):
+    """A single registered plugin's attach_fn is called once with the app."""
+    attach_fn = MagicMock()
+    app = _run_plugin_attachment(monkeypatch, plugins={"my_plugin": attach_fn})
+
+    attach_fn.assert_called_once()
+    received_app = attach_fn.call_args.args[0]
+    assert received_app is app
+
+
+def test_multiple_plugins_each_called_once(monkeypatch):
+    """Each registered plugin is called exactly once in iteration order."""
+    fn_a = MagicMock()
+    fn_b = MagicMock()
+    _run_plugin_attachment(monkeypatch, plugins={"plugin_a": fn_a, "plugin_b": fn_b})
+
+    fn_a.assert_called_once()
+    fn_b.assert_called_once()
+
+
+def test_bad_plugin_does_not_crash_server(monkeypatch):
+    """If attach_fn raises, the loop continues and returns a valid app."""
+    calls = []
+
+    def bad_attach(app):
+        raise RuntimeError("plugin broken")
+
+    def good_attach(app):
+        calls.append(app)
+
+    # bad plugin first, good plugin second — good must still run
+    app = _run_plugin_attachment(
+        monkeypatch, plugins={"broken_plugin": bad_attach, "good_plugin": good_attach}
+    )
+
+    assert isinstance(app, FastAPI)
+    # good plugin must have been called despite the earlier failure
+    assert len(calls) == 1
+    assert calls[0] is app

--- a/tests/entrypoints/test_router_plugins.py
+++ b/tests/entrypoints/test_router_plugins.py
@@ -8,9 +8,8 @@ entry points, and no fully-constructed args namespace are required.
 """
 
 import logging
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
-import pytest
 from fastapi import FastAPI
 
 
@@ -43,7 +42,7 @@ def _run_plugin_attachment(monkeypatch, plugins: dict):
 
 
 def test_no_plugins_installed(monkeypatch):
-    """No-op when no router plugins are registered; app is still a valid FastAPI instance."""
+    """No-op when no router plugins are registered; app is a valid FastAPI instance."""
     app = _run_plugin_attachment(monkeypatch, plugins={})
     assert isinstance(app, FastAPI)
 

--- a/tests/plugins/vllm_add_dummy_router/setup.py
+++ b/tests/plugins/vllm_add_dummy_router/setup.py
@@ -8,8 +8,6 @@ setup(
     version="0.1",
     packages=["vllm_add_dummy_router"],
     entry_points={
-        "vllm.router_plugins": [
-            "dummy_router = vllm_add_dummy_router:attach_router"
-        ]
+        "vllm.router_plugins": ["dummy_router = vllm_add_dummy_router:attach_router"]
     },
 )

--- a/tests/plugins/vllm_add_dummy_router/setup.py
+++ b/tests/plugins/vllm_add_dummy_router/setup.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from setuptools import setup
+
+setup(
+    name="vllm_add_dummy_router",
+    version="0.1",
+    packages=["vllm_add_dummy_router"],
+    entry_points={
+        "vllm.router_plugins": [
+            "dummy_router = vllm_add_dummy_router:attach_router"
+        ]
+    },
+)

--- a/tests/plugins/vllm_add_dummy_router/vllm_add_dummy_router/__init__.py
+++ b/tests/plugins/vllm_add_dummy_router/vllm_add_dummy_router/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Dummy router plugin for testing vllm.router_plugins entry point group.
+
+Registers two routes:
+  GET  /dummy/ping  → {"pong": true}
+  POST /dummy/echo  → echoes the JSON body back
+"""
+
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter(prefix="/dummy", tags=["dummy-router-plugin"])
+
+
+@router.get("/ping")
+async def ping() -> JSONResponse:
+    return JSONResponse({"pong": True})
+
+
+@router.post("/echo")
+async def echo(request: Request) -> JSONResponse:
+    body = await request.json()
+    return JSONResponse(body)
+
+
+def attach_router(app: FastAPI) -> None:
+    """Entry point called by vLLM build_app() via vllm.router_plugins."""
+    app.include_router(router)

--- a/tests/plugins_tests/test_router_plugins_e2e.py
+++ b/tests/plugins_tests/test_router_plugins_e2e.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""End-to-end tests for the vllm.router_plugins entry point group.
+
+Requires:
+  - A GPU (vllm starts a real inference server)
+  - The dummy plugin installed:
+      pip install -e tests/plugins/vllm_add_dummy_router/
+
+The dummy plugin registers:
+  GET  /dummy/ping  → {"pong": true}
+  POST /dummy/echo  → echoes the JSON body back
+
+Tests:
+  1. Routes added by a router plugin are reachable on the live server.
+  2. Routes appear in the OpenAPI schema (/openapi.json).
+  3. Core vLLM routes (/health, /v1/models) are unaffected.
+  4. Server starts cleanly with NO router plugins installed.
+"""
+
+import pytest
+import requests
+
+from tests.utils import RemoteOpenAIServer
+
+# Smallest model that starts quickly; enforce-eager skips CUDA graph capture.
+MODEL = "facebook/opt-125m"
+BASE_ARGS = [
+    "--dtype",
+    "float16",
+    "--max-model-len",
+    "512",
+    "--enforce-eager",
+    "--max-num-seqs",
+    "4",
+]
+
+
+@pytest.fixture(scope="module")
+def server_with_plugin():
+    """vLLM server started with the dummy_router plugin enabled."""
+    with RemoteOpenAIServer(
+        MODEL,
+        BASE_ARGS,
+        env_dict={"VLLM_PLUGINS": "dummy_router"},
+    ) as remote_server:
+        yield remote_server
+
+
+@pytest.fixture(scope="module")
+def server_no_plugins():
+    """vLLM server started with no router plugins."""
+    with RemoteOpenAIServer(
+        MODEL,
+        BASE_ARGS,
+        env_dict={"VLLM_PLUGINS": ""},
+    ) as remote_server:
+        yield remote_server
+
+
+# ---------------------------------------------------------------------------
+# Tests: server with the dummy_router plugin
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_ping_route(server_with_plugin: RemoteOpenAIServer):
+    """GET /dummy/ping returns 200 and {"pong": true}."""
+    resp = requests.get(server_with_plugin.url_for("dummy", "ping"), timeout=10)
+    assert resp.status_code == 200
+    assert resp.json() == {"pong": True}
+
+
+def test_plugin_echo_route(server_with_plugin: RemoteOpenAIServer):
+    """POST /dummy/echo returns the submitted body unchanged."""
+    payload = {"hello": "world", "count": 42}
+    resp = requests.post(
+        server_with_plugin.url_for("dummy", "echo"),
+        json=payload,
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    assert resp.json() == payload
+
+
+def test_plugin_routes_in_openapi_schema(server_with_plugin: RemoteOpenAIServer):
+    """Plugin routes appear in /openapi.json so they are discoverable by clients."""
+    resp = requests.get(server_with_plugin.url_for("openapi.json"), timeout=10)
+    assert resp.status_code == 200
+    paths = resp.json().get("paths", {})
+    assert "/dummy/ping" in paths, f"/dummy/ping missing from schema: {list(paths)}"
+    assert "/dummy/echo" in paths, f"/dummy/echo missing from schema: {list(paths)}"
+
+
+def test_core_routes_unaffected_by_plugin(server_with_plugin: RemoteOpenAIServer):
+    """Core vLLM routes remain reachable when a router plugin is loaded."""
+    health = requests.get(server_with_plugin.url_for("health"), timeout=10)
+    assert health.status_code == 200
+
+    models = requests.get(server_with_plugin.url_for("v1", "models"), timeout=10)
+    assert models.status_code == 200
+    data = models.json().get("data", [])
+    assert any(MODEL in m.get("id", "") for m in data), (
+        f"Model {MODEL!r} not listed: {data}"
+    )
+
+
+def test_completions_work_alongside_plugin(server_with_plugin: RemoteOpenAIServer):
+    """/v1/completions still works correctly when a router plugin is active."""
+    payload = {
+        "model": MODEL,
+        "prompt": "Hello,",
+        "max_tokens": 5,
+        "temperature": 0.0,
+    }
+    resp = requests.post(
+        server_with_plugin.url_for("v1", "completions"),
+        json=payload,
+        timeout=30,
+    )
+    assert resp.status_code == 200
+    choices = resp.json().get("choices", [])
+    assert len(choices) == 1
+    assert choices[0].get("text")
+
+
+# ---------------------------------------------------------------------------
+# Tests: server with NO router plugins
+# ---------------------------------------------------------------------------
+
+
+def test_no_plugins_server_starts_cleanly(server_no_plugins: RemoteOpenAIServer):
+    """/health returns 200 when no router plugins are installed."""
+    resp = requests.get(server_no_plugins.url_for("health"), timeout=10)
+    assert resp.status_code == 200
+
+
+def test_no_plugins_routes_absent(server_no_plugins: RemoteOpenAIServer):
+    """Plugin routes are absent when no router plugins are loaded."""
+    resp = requests.get(server_no_plugins.url_for("dummy", "ping"), timeout=10)
+    assert resp.status_code == 404

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -55,6 +55,7 @@ from vllm.entrypoints.utils import (
     process_lora_modules,
 )
 from vllm.logger import init_logger
+from vllm.plugins import load_plugins_by_group
 from vllm.reasoning import ReasoningParserManager
 from vllm.tasks import POOLING_TASKS, SupportedTask
 from vllm.tool_parsers import ToolParserManager
@@ -311,12 +312,13 @@ def build_app(
     # "vllm.router_plugins" entry point group.
     # Each entry point must be a callable that accepts a FastAPI app:
     #   def attach_router(app: FastAPI) -> None: ...
-    from vllm.plugins import load_plugins_by_group
-
     router_plugins = load_plugins_by_group("vllm.router_plugins")
     for name, attach_fn in router_plugins.items():
         logger.debug("Attaching router plugin: %s", name)
-        attach_fn(app)  # type: ignore[call-arg]
+        try:
+            attach_fn(app)  # type: ignore[call-arg]
+        except Exception:
+            logger.exception("Failed to attach router plugin: %s", name)
 
     return app
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -305,6 +305,19 @@ def build_app(
             )
 
     app = sagemaker_standards_bootstrap(app)
+
+    # Load router plugins — external packages that attach additional HTTP
+    # endpoints to the vLLM server by registering under the
+    # "vllm.router_plugins" entry point group.
+    # Each entry point must be a callable that accepts a FastAPI app:
+    #   def attach_router(app: FastAPI) -> None: ...
+    from vllm.plugins import load_plugins_by_group
+
+    router_plugins = load_plugins_by_group("vllm.router_plugins")
+    for name, attach_fn in router_plugins.items():
+        logger.debug("Attaching router plugin: %s", name)
+        attach_fn(app)  # type: ignore[call-arg]
+
     return app
 
 

--- a/vllm/plugins/__init__.py
+++ b/vllm/plugins/__init__.py
@@ -25,7 +25,7 @@ STAT_LOGGER_PLUGINS_GROUP = "vllm.stat_logger_plugins"
 plugins_loaded = False
 
 
-def load_plugins_by_group(group: str) -> dict[str, Callable[[], Any]]:
+def load_plugins_by_group(group: str) -> dict[str, Callable[..., Any]]:
     """Load plugins registered under the given entry point group."""
     from importlib.metadata import entry_points
 
@@ -51,7 +51,7 @@ def load_plugins_by_group(group: str) -> dict[str, Callable[[], Any]]:
             "Set `VLLM_PLUGINS` to control which plugins to load."
         )
 
-    plugins = dict[str, Callable[[], Any]]()
+    plugins = dict[str, Callable[..., Any]]()
     for plugin in discovered_plugins:
         if allowed_plugins is None or plugin.name in allowed_plugins:
             if allowed_plugins is not None:


### PR DESCRIPTION
## Summary

- Adds support for external packages to attach additional HTTP endpoints to the vLLM server by registering under the `vllm.router_plugins` entry point group.
- Each registered callable receives the FastAPI `app` instance and is expected to call `app.include_router(...)`.
- Loaded at the end of `build_app()`, after all built-in routers and middleware, so plugins see a fully configured app.
- Unlike `vllm.general_plugins` (loaded in all processes), router plugins are only invoked in the HTTP server process.

## Motivation

This is a prerequisite for the [`vllm-lora-scaler`](https://github.com/wangchen615/vllm-lora-scaler) plugin (issue #15), which attaches `POST /v1/scale_max_loras` to dynamically resize LoRA GPU slots. Without this hook, external packages have no clean way to add new API endpoints without modifying vLLM core.

## Test plan

- [ ] `VLLM_PLUGINS=lora_scaler vllm serve ...` loads the plugin and `/v1/scale_max_loras` appears in the OpenAPI schema
- [ ] Server starts cleanly with no router plugins installed (no entry points → no-op)
- [ ] Existing routes unaffected

## Notes

- No duplicate PR exists in `vllm-project/vllm` for this exact entry point group mechanism.
- AI assistance was used; all changed lines have been reviewed by the submitter.

Closes #15