### PR TITLE
[Core] Disable LoRA CudaGraph specialization when dynamic_lora_slots=True

### DIFF
--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -117,6 +117,13 @@ class CudagraphDispatcher:
             # No LoRA configured - single case with no LoRA
             return [0]
 
+        if lora_config.dynamic_lora_slots:
+            logger.warning(
+                "dynamic_lora_slots=True: disabling LoRA cudagraph "
+                "specialization. This may reduce throughput slightly."
+            )
+            return [0]
+
         # LoRA is enabled - capture graphs based on cudagraph_specialize_lora
         if self.compilation_config.cudagraph_specialize_lora:
             captured_counts = get_captured_lora_counts(


### PR DESCRIPTION
## Summary

- When `dynamic_lora_slots=True`, `_get_lora_cases()` now returns `[0]` to skip LoRA-specific CUDA graph specialization
- Logs a warning at startup so operators know specialization is disabled
- Existing behavior unchanged when `dynamic_lora_slots=False`

## Motivation

Dynamic slot reallocation deallocates and reallocates `lora_a_stacked` / `lora_b_stacked` tensors, invalidating any CUDA graph captured with old tensor addresses. This safely disables LoRA graph specialization to avoid silently using stale graphs.

**Parent Epic**: #4

## Test plan

- [ ] `pre-commit run --all-files` passes (ruff, mypy clean)
- [ ] Existing cudagraph tests pass when `dynamic_lora_slots=False`
- [ ] Warning logged when `dynamic_lora_slots=True` and server starts
- [ ] `_get_lora_cases()` returns `[0]` (no LoRA specialization) when dynamic

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)