### PR TITLE
[Core] Disable LoRA CudaGraph specialization when dynamic_lora_slots=True

### DIFF
--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -38,7 +38,7 @@ class SimpleMLP(nn.Module):
 def _create_vllm_config(
     compilation_config: CompilationConfig,
     max_num_seqs: int = 8,
-    lora_config: bool = False,
+    lora_config: bool | LoRAConfig = False,
 ) -> MagicMock:
     mock_config = MagicMock(spec=VllmConfig)
     mock_config.compilation_config = compilation_config
@@ -47,7 +47,9 @@ def _create_vllm_config(
     )
     mock_config.parallel_config = ParallelConfig()
     mock_config.speculative_config = None  # No speculative decoding
-    if not lora_config:
+    if isinstance(lora_config, LoRAConfig):
+        mock_config.lora_config = lora_config
+    elif not lora_config:
         mock_config.lora_config = None
     else:
         # Create a real LoRAConfig with specialize_active_lora enabled
@@ -263,6 +265,42 @@ class TestCudagraphDispatcher:
         # Don't initialize keys
 
         assert dispatcher.get_capture_descs() == []
+
+    def test_dynamic_lora_slots_disables_lora_cudagraphs(self):
+        """dynamic_lora_slots=True should return [0] from _get_lora_cases
+        and dispatch LoRA-active batches as CUDAGraphMode.NONE."""
+        comp_config = CompilationConfig(
+            cudagraph_mode="PIECEWISE",
+            mode=CompilationMode.VLLM_COMPILE,
+            cudagraph_capture_sizes=[1, 8],
+        )
+        config = _create_vllm_config(
+            comp_config,
+            max_num_seqs=8,
+            lora_config=LoRAConfig(
+                max_loras=4,
+                dynamic_lora_slots=True,
+                specialize_active_lora=True,
+            ),
+        )
+        dispatcher = CudagraphDispatcher(config)
+
+        # _get_lora_cases should return [0] (no LoRA specialization)
+        assert dispatcher._get_lora_cases() == [0]
+
+        dispatcher.initialize_cudagraph_keys(
+            cudagraph_mode=comp_config.cudagraph_mode,
+            uniform_decode_query_len=1,
+        )
+
+        # Only no-LoRA keys: 2 sizes × 1 lora_case = 2 keys
+        assert len(dispatcher.cudagraph_keys[CUDAGraphMode.PIECEWISE]) == 2
+
+        # LoRA-active batch should fall back to NONE
+        rt_mode, _ = dispatcher.dispatch(
+            num_tokens=8, uniform_decode=False, has_lora=True
+        )
+        assert rt_mode == CUDAGraphMode.NONE
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -117,10 +117,14 @@ class CudagraphDispatcher:
             # No LoRA configured - single case with no LoRA
             return [0]
 
+        # Dynamic slots reallocate LoRA tensors, invalidating captured
+        # graph addresses.
         if lora_config.dynamic_lora_slots:
-            logger.warning(
-                "dynamic_lora_slots=True: disabling LoRA cudagraph "
-                "specialization. This may reduce throughput slightly."
+            logger.warning_once(
+                "dynamic_lora_slots=True: disabling CUDA graphs for LoRA "
+                "requests due to dynamic tensor reallocation. This "
+                "overrides cudagraph_specialize_lora and may reduce "
+                "throughput for LoRA-enabled requests."
             )
             return [0]
 

--- a/vllm/v1/cudagraph_dispatcher.py
+++ b/vllm/v1/cudagraph_dispatcher.py
@@ -117,6 +117,13 @@ class CudagraphDispatcher:
             # No LoRA configured - single case with no LoRA
             return [0]
 
+        if lora_config.dynamic_lora_slots:
+            logger.warning(
+                "dynamic_lora_slots=True: disabling LoRA cudagraph "
+                "specialization. This may reduce throughput slightly."
+            )
+            return [0]
+
         # LoRA is enabled - capture graphs based on cudagraph_specialize_lora
         if self.compilation_config.cudagraph_specialize_lora:
             captured_counts = get_captured_lora_counts(


### PR DESCRIPTION
## Summary

- When `dynamic_lora_slots=True`, `_get_lora_cases()` now returns `[0]` to skip LoRA-specific CUDA graph specialization
- Logs a warning at startup so operators know specialization is disabled
- Existing behavior unchanged when `dynamic_lora_slots=False`

## Motivation

Dynamic slot reallocation deallocates and reallocates `lora_a_stacked` / `lora_b_stacked` tensors, invalidating any CUDA graph captured with old tensor addresses. This safely disables LoRA graph specialization to avoid silently using stale graphs.

**Parent Epic**: #4

## Test plan

- [ ] `pre-commit run --all-files` passes (ruff, mypy clean)
- [ ] Existing cudagraph tests pass when `dynamic_lora_slots=False`
- [ ] Warning logged when `dynamic_lora_slots=True` and server starts
- [ ] `_get_lora_cases()` returns `[0]` (no LoRA specialization) when dynamic

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)