### PR TITLE
[Core] Expose resize_lora_slots() as RPC target on WorkerLoRAManager and GPUWorker

### DIFF
--- a/tests/lora/test_lora_model_manager_resize.py
+++ b/tests/lora/test_lora_model_manager_resize.py
@@ -141,3 +141,30 @@ def test_empty_cache_called_once():
     with patch("torch.accelerator.empty_cache") as mock_empty:
         manager.resize_lora_slots(8)
     mock_empty.assert_called_once()
+
+
+# --- WorkerLoRAManager delegation tests ---
+
+
+def test_worker_manager_resize_delegates():
+    """WorkerLoRAManager.resize_lora_slots delegates to _adapter_manager."""
+    from vllm.lora.worker_manager import WorkerLoRAManager
+
+    worker = MagicMock(spec=WorkerLoRAManager)
+    worker._adapter_manager = MagicMock()
+    worker._adapter_manager.resize_lora_slots = MagicMock()
+    # Bind the real method
+    worker.resize_lora_slots = WorkerLoRAManager.resize_lora_slots.__get__(worker)
+    worker.resize_lora_slots(8)
+    worker._adapter_manager.resize_lora_slots.assert_called_once_with(8)
+
+
+def test_worker_manager_lora_slots_delegates():
+    """WorkerLoRAManager.lora_slots reflects _adapter_manager.lora_slots."""
+    from vllm.lora.worker_manager import WorkerLoRAManager
+
+    worker = MagicMock(spec=WorkerLoRAManager)
+    worker._adapter_manager = MagicMock()
+    type(worker._adapter_manager).lora_slots = PropertyMock(return_value=6)
+    # Bind the real property
+    assert WorkerLoRAManager.lora_slots.fget(worker) == 6

--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -247,6 +247,14 @@ class WorkerLoRAManager:
     def list_adapters(self) -> set[int]:
         return set(self._adapter_manager.list_adapters())
 
+    def resize_lora_slots(self, new_slots: int) -> None:
+        """Resize GPU LoRA slots. Called by engine via collective RPC."""
+        self._adapter_manager.resize_lora_slots(new_slots)
+
+    @property
+    def lora_slots(self) -> int:
+        return self._adapter_manager.lora_slots
+
 
 class LRUCacheWorkerLoRAManager(WorkerLoRAManager):
     """WorkerLoRAManager that manages LoRA models on the worker side.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -904,17 +904,15 @@ class Worker(WorkerBase):
 
     def resize_lora_slots(self, new_slots: int) -> None:
         """RPC target: resize LoRA slots on this worker."""
-        if hasattr(self.model_runner, "lora_manager") and (
-            self.model_runner.lora_manager is not None
-        ):
-            self.model_runner.lora_manager.resize_lora_slots(new_slots)
+        lora_manager = getattr(self.model_runner, "lora_manager", None)
+        if lora_manager is not None:
+            lora_manager.resize_lora_slots(new_slots)
 
     def get_lora_slots(self) -> int:
         """RPC target: return current LoRA slot count."""
-        if hasattr(self.model_runner, "lora_manager") and (
-            self.model_runner.lora_manager is not None
-        ):
-            return self.model_runner.lora_manager.lora_slots
+        lora_manager = getattr(self.model_runner, "lora_manager", None)
+        if lora_manager is not None:
+            return lora_manager.lora_slots
         return 0
 
     def check_health(self) -> None:

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -902,6 +902,21 @@ class Worker(WorkerBase):
     def pin_lora(self, lora_id: int) -> bool:
         return self.model_runner.pin_lora(lora_id)
 
+    def resize_lora_slots(self, new_slots: int) -> None:
+        """RPC target: resize LoRA slots on this worker."""
+        if hasattr(self.model_runner, "lora_manager") and (
+            self.model_runner.lora_manager is not None
+        ):
+            self.model_runner.lora_manager.resize_lora_slots(new_slots)
+
+    def get_lora_slots(self) -> int:
+        """RPC target: return current LoRA slot count."""
+        if hasattr(self.model_runner, "lora_manager") and (
+            self.model_runner.lora_manager is not None
+        ):
+            return self.model_runner.lora_manager.lora_slots
+        return 0
+
     def check_health(self) -> None:
         # worker will always be healthy as long as it's running.
         return


### PR DESCRIPTION
## Summary

- Add `resize_lora_slots(new_slots)` method and `lora_slots` property to `WorkerLoRAManager`, delegating to `LoRAModelManager`
- Add `resize_lora_slots(new_slots)` and `get_lora_slots()` RPC targets to `Worker` in `gpu_worker.py`
- No-op when LoRA manager is not initialized

## Motivation

The engine needs to broadcast LoRA slot resizes to all TP workers via `collective_rpc("resize_lora_slots", args=(N,))`. This wires the plumbing from `GPUWorker` → `WorkerLoRAManager` → `LoRAModelManager.resize_lora_slots()` (added in #11).

**Parent Epic**: #4

## Test plan

- [ ] `pre-commit run --all-files` passes (ruff, mypy clean)
- [ ] `resize_lora_slots()` delegates correctly to `LoRAModelManager`
- [ ] `get_lora_slots()` returns 0 when no LoRA manager present
- [ ] Existing LoRA tests unaffected

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/claude-code)