### PR TITLE
ci: auto-trigger Codex review on PR open and new commits

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -20,6 +20,10 @@ name: codex-review
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
+    # Only review PRs targeting dev. All active development on this fork
+    # merges into dev, not main; main is kept synced with upstream.
+    branches:
+      - dev
 
 # One in-flight retrigger per PR. If you push three commits in a burst,
 # only the last one posts the @codex review comment. Cancels stale runs.

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,56 @@
+name: codex-review
+
+# Auto-trigger Codex review on every PR open and every new commit.
+#
+# Why this workflow exists:
+#   The Codex GitHub App's account-level "Automatic reviews" setting only
+#   covers PRs the account owner authors. PRs opened by collaborators,
+#   dependabot, or anyone else are not auto-reviewed, and Codex doesn't
+#   re-review on subsequent pushes either. This workflow posts an
+#   `@codex review` comment on every relevant event, so every PR — no
+#   matter who opened it, and at every push — gets reviewed.
+#
+# Cost: zero. Codex bills against the App owner's Codex budget; this
+# workflow only posts a comment.
+#
+# Setup: just merge this file. No secrets, no API keys.
+#   The default GITHUB_TOKEN has enough permission to comment on PRs in
+#   the same repository.
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+# One in-flight retrigger per PR. If you push three commits in a burst,
+# only the last one posts the @codex review comment. Cancels stale runs.
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retrigger:
+    # Skip:
+    #   - draft PRs (Codex skips them too — retriggering is wasted)
+    #   - the upstream repo if this branch is ever synced there
+    #   - PRs you author yourself ON THE 'opened'/'reopened'/'ready_for_review'
+    #     events: your account-level Codex auto-review already covers those.
+    #     We DO still trigger on 'synchronize' for your own PRs, since
+    #     Codex doesn't re-review on push.
+    if: |
+      github.repository == 'wangchen615/vllm' &&
+      github.event.pull_request.draft == false &&
+      !(github.event.pull_request.user.login == 'wangchen615' && github.event.action != 'synchronize')
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Post @codex review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" \
+            --body "@codex review"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codex-review.yml` that posts `@codex review` on `opened` / `reopened` / `ready_for_review` / `synchronize`.
- Covers PRs from any author (the account-level Codex auto-review only covers PRs I open myself) and triggers a fresh review on every new commit.
- Skips draft PRs, the upstream repo, and my own PRs on open/reopen/ready (where my Codex account auto-review already runs) — so no duplicate spend.

## Why

The Codex GitHub App's account-level "Automatic reviews" setting only auto-reviews PRs I author, and it doesn't re-review on subsequent pushes. To get every PR reviewed and every push re-reviewed, someone has to comment `@codex review`. This workflow does it automatically.

## Test plan

- [ ] Merge this PR. The workflow itself doesn't fire on its own merge into main (it only watches `pull_request` events), so testing requires a follow-up PR.
- [ ] After merge, open a small follow-up PR (any branch). Confirm `@codex review` is posted automatically by `github-actions[bot]`, then Codex replies with a review.
- [ ] Push a new commit to that follow-up PR. Confirm a fresh `@codex review` comment goes out and Codex re-reviews against the new SHA.
- [ ] (Skip-path check) Open a PR I author myself. Confirm the workflow does NOT post `@codex review` on the `opened` event (since my account auto-review handles that).

AI assistance (Claude) was used to draft this workflow; I reviewed end-to-end before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)